### PR TITLE
Fix CSV export

### DIFF
--- a/src/libs/csv.js
+++ b/src/libs/csv.js
@@ -22,6 +22,7 @@ function flat2nested(obj) {
 
 var nested2flat = function (obj) {
     var flat = {}
+    var key = null
     for (var i in obj) {
         if (obj[i] === null || typeof obj[i] != 'object') {
             flat[i] = obj[i]; continue


### PR DESCRIPTION
JS error due to undefined variable.  This was likely working before we had to upgrade Aurelia (framework), but now that Aurelia uses webpack it doesn't like undefined vars.